### PR TITLE
RF/FIX: Restructuring

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
 	"maintainer": "Joe Wexler",
 	"cite": "",
 	"license": "MIT",
-	"url": "",
+	"url": "https://github.com/poldracklab/wbhi-redcap-gear",
 	"source": "",
 	"environment": {
 		"FLYWHEEL": "/flywheel/v0",


### PR DESCRIPTION
Realized the copying errors we were seeing were because copying wasn't enabled on certain projects - probably have some way to do it through the SDK but for now went through the web ui and changed them.

Mostly refactoring and additional log messages, but changes some things:
- makes time comparison in `get_sessions_redcap()` timezone aware
- extracting out logic for needing to run `deid-export` into a standalone function
  - this is consistently failing for the only subject hitting:
```
log.info('No session %s found for subject %s in deid project', session_label, sub_label)
```
which makes me think something may have gone wrong with copying / tagging.