### PR TITLE
Fix/add checks

### DIFF
--- a/run.py
+++ b/run.py
@@ -40,17 +40,24 @@ log = logging.getLogger(__name__)
 WAIT_TIMEOUT = 3600 * 2
 
 
+def timedelta_from_now(in_timestamp: datetime, tz_from_utc: int = -8) -> timedelta:
+    now = datetime.now(timezone.utc)
+    PST = timezone(timedelta(hours=tz_from_utc))
+    UTC_timestamp = in_timestamp.replace(tzinfo=PST).astimezone(timezone.utc)
+    return now - UTC_timestamp
+
+
 def get_sessions_pi_copy(fw_project: ProjectOutput) -> list:
     """Get and filter sessions for pi_copy()"""
     sessions = []
-    now = datetime.now(timezone.utc)
-    PST = timezone(timedelta(hours=-8))
     for session in fw_project.sessions():
         if any(tag.startswith('copied_') for tag in session.tags):
             continue
-        timestamp = session.timestamp.replace(tzinfo=PST).astimezone(timezone.utc)
-        if (now - timestamp) < timedelta(hours=6):
-            log.info('Skipping pi_copy of session %s because less than 6 hours have passed.' % session.label)
+        if timedelta_from_now(session.timestamp) < timedelta(hours=6):
+            log.info(
+                'Skipping pi_copy of session %s because less than 6 hours have passed.'
+                % session.label
+            )
             continue
 
         sessions.append(session)
@@ -61,9 +68,6 @@ def get_sessions_redcap(fw_project: ProjectOutput) -> list:
     """Get and filter sessions for redcap_match_mv"""
     sessions = []
     today = datetime.today()
-    now = datetime.now(timezone.utc)
-    # MG: Does not account for daylight savings (-7) but should be precise enough
-    PST = timezone(timedelta(hours=-8))
     for session in fw_project.sessions():
         if 'skip_redcap' in session.tags or 'need_to_split' in session.tags:
             log.info('Skipping session %s due to tag', session.label)
@@ -74,12 +78,10 @@ def get_sessions_redcap(fw_project: ProjectOutput) -> list:
                 session.label,
             )
             continue
-
-        # Convert from PST to UTC
-        timestamp = session.timestamp.replace(tzinfo=PST).astimezone(timezone.utc)
-        if (now - timestamp) < timedelta(days=config['ignore_until_n_days_old']):
+        if timedelta_from_now(session.timestamp) < timedelta(
+            days=config['ignore_until_n_days_old']
+        ):
             continue
-
         redcap_tags = [t for t in session.tags if t.startswith('redcap')]
         if not redcap_tags:
             sessions.append(session)
@@ -216,7 +218,7 @@ def create_view_df(container, columns: list, filter=None) -> pd.DataFrame:
         builder.column(src=c)
 
     view = builder.build()
-    return client.read_view_dataframe(view, container.id)
+    return client.read_view_dataframe(view, container.id, opts={"dtype": {"subject.label": str}})
 
 
 def smart_copy(

--- a/run.py
+++ b/run.py
@@ -43,9 +43,16 @@ WAIT_TIMEOUT = 3600 * 2
 def get_sessions_pi_copy(fw_project: ProjectOutput) -> list:
     """Get and filter sessions for pi_copy()"""
     sessions = []
+    now = datetime.now(timezone.utc)
+    PST = timezone(timedelta(hours=-8))
     for session in fw_project.sessions():
         if any(tag.startswith('copied_') for tag in session.tags):
             continue
+        timestamp = session.timestamp.replace(tzinfo=PST).astimezone(timezone.utc)
+        if (now - timestamp) < timedelta(hours=6):
+            log.info('Skipping pi_copy of session %s because less than 6 hours have passed.' % session.label)
+            continue
+
         sessions.append(session)
     return sessions
 


### PR DESCRIPTION
This adds two checks to prevent issues that have arisen:
1) A check to make sure sessions have a "copied_<pi_id>" tag before matching. This prevents the scenario where pi_copy fails, the session gets matched and moved to wbhi/pre-deid, and the sessions never gets copied to a pi project.
2) A check to make sure session time stamps were greater than 6hrs prior to the current time. Since the gear is sometimes run during the middle of the day for testing purposes, this prevents partial sessions from being copied and tagged with "copied_<pi_id>" prior to the end of the session being uploaded.

It also fixes the issue of subject.id being stored as int in dataviews if all the subject.id's are numerical. It now stores them as strings which preserves zero-padding.