### PR TITLE
Feat/audit checks

### DIFF
--- a/run.py
+++ b/run.py
@@ -735,11 +735,11 @@ def long_redcap_interval_tag(
     """Checks whether the interval between the session and redcap record is > 2 weeks.
     If so, tags the session with 'long-redcap-interval_unsent'."""
     max_delta = timedelta(days=14)
-    interval_delta = (
+    interval_delta = abs(
         datetime.strptime(record['consent_timestamp'], DATETIME_FORMAT_RC)
         - hdr_fields['date']
     )
-    if interval_delta > max_delta or interval_delta < -max_delta:
+    if interval_delta > max_delta:
         tag = 'long-redcap-interval_unsent'
         if tag not in session.tags:
             add_tag_wrapper(session, tag)


### PR DESCRIPTION
This PR introduces two new checks:
- long_redcap_interval_tag(): Checks whether the interval between a matched flywheel session and the corresponding redcap record is greater than 2 weeks. If so, tag that session (but still allow the match). This is useful because the redcap surveys contain health-related questions that should be answered around the time of the scan in order for them to be useful.
- check_software_version(): Checks whether the software version in the dicom headers matches the what we have on record from that site, stored in [wbhi-utils/contants.py.](https://github.com/poldracklab/wbhi-utils/blob/main/wbhiutils/constants.py). Tags the session if it finds a mismatch.

Soon I'll be adding more audits to https://github.com/jbwexler/wbhi-email-gear, which will include reporting any sessions that are tagged with the above tags.

