### PR TITLE
Fix/minor fixes

### DIFF
--- a/run.py
+++ b/run.py
@@ -337,18 +337,24 @@ def check_copied_acq_exist(acq_list: list, pi_project: ProjectOutput) -> None:
             )
             acq_list_failed.append(acq)
         else:
-            try:
+            if to_copy_tag in acq.tags: 
                 acq.delete_tag(to_copy_tag)
+            else:
+                log.warning('Acq %s can\'t delete %s because it doesn\'t contain that tag.',
+                    acq.id,
+                    to_copy_tag,
+                )
+            if copied_tag not in acq.tags:
                 acq.add_tag(copied_tag)
-            except Exception:
-                breakpoint()
-            # flywheel.rest.ApiException: (409) Reason: Tag already exists
-            # tmp/ucsd_qa to ucsd/qa
+            else:
+                log.warning('Acq %s can\'t add %s because it already contains that tag.',
+                    acq.id,
+                    copied_tag,
+                )
 
     if acq_list_failed:
         acq_labels = [(acq.parents.session, acq.label) for acq in acq_list_failed]
         log.error('%s failed to smart-copy to %s', acq_labels, pi_project.label)
-        sys.exit(1)
 
     # Tag session if all acqs are tagged to save time when filtering sessions in future runs
     for session_id in session_set:


### PR DESCRIPTION
This fixes two minor things:
1) Better handle errors in check_copied_acq_exist(). Most significantly, it no longer exits when there are errors with smart-copying. Acquisitions that failed to smart-copy will not be tagged as such and thus there is no need to exit. The next gear run will re-attempt to smart-copy.
2) Use session.id instead of session.label in logs, as IDs are more useful and easier to search for on the website.